### PR TITLE
Auto show error bug

### DIFF
--- a/frontend/src/componentsStatic/App.tsx
+++ b/frontend/src/componentsStatic/App.tsx
@@ -48,6 +48,7 @@ const App: React.FC = () => {
   const [activeLanguage, setActiveLanguage] = useState("Mandarin");
 
   const [qaMode, setQAMode] = useState(false);
+  const [forceScroll, setForceScroll] = useState(false);
 
   // Dataset
   const [dataset, setDataset] = useState<DatasetType | null>(null);
@@ -132,10 +133,11 @@ const App: React.FC = () => {
       // Apply highlight to the clicked row
       if (rowElement) {
         rowElement.classList.add("active-db-row");
-        // Scroll the row into view
-        rowElement.scrollIntoView({ behavior: "smooth", block: "center" });
       }
 
+      // Force scroll to the current sentence
+      setForceScroll(true);
+      
       // Show success toast 
       const modeText = qaMode ? "QA-ed" : "annotated";
       toast.success(`Navigated to the next un${modeText} sentence`);
@@ -285,8 +287,6 @@ const App: React.FC = () => {
         // Apply highlight to the clicked row
         if (rowElement) {
           rowElement.classList.add("active-db-row");
-          // Scroll the row into view
-          // rowElement.scrollIntoView({ behavior: "smooth", block: "center" });
         }
 
         // Reset States
@@ -353,6 +353,8 @@ const App: React.FC = () => {
               setQAMode={setQAMode}
               activeLanguage={activeLanguage}
               setActiveLanguage={setActiveLanguage}
+              forceScroll={forceScroll}
+              setForceScroll={setForceScroll}
             />
             <div className='annotator-selector'>
               {qaMode && (

--- a/frontend/src/componentsStatic/App.tsx
+++ b/frontend/src/componentsStatic/App.tsx
@@ -98,6 +98,26 @@ const App: React.FC = () => {
       setDiffContent(lastUnannotatedSentence.mt);
       setSentenceID(lastUnannotatedSentence._id);
       setModifiedText(lastUnannotatedSentence.mt);
+      
+      // Check if there are existing annotations for this sentence and annotator
+      if (qaMode && annotator && lastUnannotatedSentence.annotations && lastUnannotatedSentence.annotations[`${annotator}_annotations`]) {
+        // Load existing annotation spans
+        const prev_annotation = lastUnannotatedSentence.annotations[`${annotator}_annotations`];
+        const modified_spans = prev_annotation.annotatedSpans.map(span => ({
+          ...span,
+          original_text: span.error_text_segment,
+          start_index_translation: span.start_index,
+          end_index_translation: span.end_index,
+        }));
+        setErrorSpans(modified_spans);
+        setAddedErrorSpans(modified_spans);
+        setDiffContent(prev_annotation.corrected_sentence);
+        setModifiedText(prev_annotation.corrected_sentence);
+      } else {
+        // Clear if no existing annotations
+        setErrorSpans([]);
+        setAddedErrorSpans([]);
+      }
 
       // Remove active class from all rows first
       document.querySelectorAll('[class^="db-row-"]').forEach((row) => {
@@ -233,6 +253,26 @@ const App: React.FC = () => {
           setDiffContent(nextSentence.mt);
           setSentenceID(nextSentence._id);
           setModifiedText(nextSentence.mt);
+          
+          // Check if there are existing annotations for this sentence and annotator
+          if (qaMode && annotator && nextSentence.annotations && nextSentence.annotations[`${annotator}_annotations`]) {
+            // Load existing annotation spans
+            const prev_annotation = nextSentence.annotations[`${annotator}_annotations`];
+            const modified_spans = prev_annotation.annotatedSpans.map(span => ({
+              ...span,
+              original_text: span.error_text_segment,
+              start_index_translation: span.start_index,
+              end_index_translation: span.end_index,
+            }));
+            setErrorSpans(modified_spans);
+            setAddedErrorSpans(modified_spans);
+            setDiffContent(prev_annotation.corrected_sentence);
+            setModifiedText(prev_annotation.corrected_sentence);
+          } else {
+            // Clear if no existing annotations
+            setErrorSpans([]);
+            setAddedErrorSpans([]);
+          }
         }
 
         // Remove active class from all rows first
@@ -251,7 +291,6 @@ const App: React.FC = () => {
 
         // Reset States
         setOverallScore(50);
-        setErrorSpans([]);
         // setSpanSeverity("Minor");
         setSpanSeverity("");
         // setTranslatedText(machineTranslation);

--- a/frontend/src/componentsStatic/scoring/DatabaseSentenceView.tsx
+++ b/frontend/src/componentsStatic/scoring/DatabaseSentenceView.tsx
@@ -70,6 +70,8 @@ type DatabaseSentenceViewProps = {
   setQAMode: React.Dispatch<React.SetStateAction<boolean>>;
   activeLanguage: string;
   setActiveLanguage: React.Dispatch<React.SetStateAction<string>>;
+  forceScroll: boolean;
+  setForceScroll: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const DatabaseSentenceView: React.FC<DatabaseSentenceViewProps> = ({
@@ -92,7 +94,9 @@ export const DatabaseSentenceView: React.FC<DatabaseSentenceViewProps> = ({
   qaMode,
   setQAMode,
   activeLanguage,
-  setActiveLanguage
+  setActiveLanguage,
+  forceScroll,
+  setForceScroll
 }) => {
   const [row_active, setRow_active] = useState<boolean>(false);
 
@@ -104,6 +108,44 @@ export const DatabaseSentenceView: React.FC<DatabaseSentenceViewProps> = ({
                        'announced the invention of a new diagnostic tool that can sort cells by ' + 
                        'type: a tiny printable chip that can be manufactured using standard '+
                        'inkjet printers for possibly about one U.S. cent each.'
+
+  // Function to scroll to the current sentence in the database view
+  const scrollToCurrentSentence = (sentenceId: string) => {
+    const currentSentence = sentenceData.find(item => item._id === sentenceId);
+    if (currentSentence) {
+      const rowElement = document.querySelector(`.db-row-${currentSentence.id}`) as HTMLElement;
+      if (rowElement) {
+        const dbViewContainer = document.querySelector('.db-sentence-view') as HTMLElement;
+        if (dbViewContainer) {
+          // Calculate the scroll offset to center
+          const rowTop = rowElement.offsetTop;
+          const containerHeight = dbViewContainer.clientHeight;
+          const rowHeight = rowElement.clientHeight;
+          
+          const targetScrollTop = rowTop - (containerHeight / 2) + (rowHeight / 2);
+          
+          dbViewContainer.scrollTo({
+            top: targetScrollTop,
+            behavior: 'smooth'
+          });
+        }
+      }
+    }
+  };
+
+  // Effect to scroll to current sentence when sentenceID changes or forceScroll is triggered
+  useEffect(() => {
+    if (sentenceID && sentenceID !== "undefined_id") {
+      scrollToCurrentSentence(sentenceID);
+    }
+  }, [sentenceID, sentenceData, forceScroll]);
+
+  // Reset forceScroll after it's been used
+  useEffect(() => {
+    if (forceScroll) {
+      setForceScroll(false);
+    }
+  }, [forceScroll, setForceScroll]);
 
   // useEffect(() => {
   //   fetch("/mandarin_dataset.json")


### PR DESCRIPTION
#19 
1. Error spans show up automatically when the next sentence is loaded for QA. 
2. Added automatic scroll behavior to the DB sentence view container so that the newly loaded sentence is always re-centered in view. Now, whenever the next sentence is loaded, the container automatically scrolls to re-center on it. This ensures that users always know which sentence they are working on, even if they had scrolled far away in the view previously.